### PR TITLE
[spameater] fix a pattern matching line

### DIFF
--- a/modules/postfix/files/spameater.py
+++ b/modules/postfix/files/spameater.py
@@ -72,7 +72,7 @@ def getLabel(fullAddress):
   r = re.match("'(.+)'[\s]*<" + emailAddressRegex + ">$", fullAddress)
   if r:
     return r.group(1)
-  r = re.match("(.+)[\s]*<" + emailAddressRegex + ">$", fullAddress)
+  r = re.match("(.*\S)[\s]*<" + emailAddressRegex + ">$", fullAddress)
   if r:
     return r.group(1)
   r = re.match("<" + emailAddressRegex + ">$", fullAddress)


### PR DESCRIPTION
`user <email@domain.com>` used to be split into
`user ` and `email@domain.com`
And the extra space next to the user was not stripped later on.
As a result, the computed `From:` header became
`user  - email@domain.com <randominstring@erine.email>`, (note the two spaces).
This commit now excludes the space from the `user` group pattern matching.