### PR TITLE
Add "first contact" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 *erine.email* is a strong shield for your emails against spam. Based on
 unlimited disposable email addresses, *erine.email* is completely free,
-open-source, and simple. Really. [Check it out!](https://erine.email).
+open-source, and simple. Really. [Check it out!](https://erine.email)
 
 This repo is the piece of software that you need to host
 *erine.email* on your own server.


### PR DESCRIPTION
The *first_shot* feature (or *first_contact*) is introduced
as a 4th possible use for the spameater instance.
Sometimes, the spameater human user will initiate themself
the contact with a remote non-trusted third party.
e.g.  a spameater user (judy) wants to initiate a contact
to a foreign address (billing@company-brand-55.com)
<judy@example.org>.

She will therefore send an email to
<brand55.judy.billing_company-brand-55.com@erine.email>.

The spameater instance job will be to relay this email
- From: <brand55.judy@erine.email>
- To:   <billing@company-brand-55.com>

This commit also creates creates 4 "constants" to be used
in several conditionals inside the script (one for each spameater
possible job).