### PR TITLE
[spameater] fix debug line for SQL request failure

### DIFF
--- a/modules/postfix/files/spameater.py
+++ b/modules/postfix/files/spameater.py
@@ -99,7 +99,7 @@ def execQuery(query, *params):
   try:
     dbCursor.execute(query, params)
   except Exception as e:
-    raise DeferException("While executing the following query: {}\nWith the following parameters: {}\nThe following exception raised: {}".format(query, ', '.join(params), str(e)))
+    raise DeferException("While executing the following query: {}\nWith the following parameters: {}\nThe following exception raised: {}".format(query, ', '.join(map(str, params)), str(e))
 
 # Extract email address from a complete address
 # Bounce email on invalid fullAddress


### PR DESCRIPTION
Context: an exception could be raised, within the `execQuery` exception block, when one of the parameters was not a string (e.g. a number):
```
>>> ', '.join(['a',2,'c'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sequence item 1: expected string, int found
```